### PR TITLE
🐛 fix(views): changing abilities page aligment

### DIFF
--- a/src/views/AbilitiesView.vue
+++ b/src/views/AbilitiesView.vue
@@ -31,5 +31,6 @@
     display: flex;
     flex-direction: column;
     gap: 16px;
+    align-items: flex-start;
   }
 </style>


### PR DESCRIPTION
This changes the abilities main page aligment to `flex-start` in order to make the table more flexible. 🧪