### PR TITLE
🐛 fix(sidebar): correcting menu element size

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -190,6 +190,10 @@
         li:first-of-type {
           display: none;
         }
+
+        li {
+          width: 100%;
+        }
       }
     }
 


### PR DESCRIPTION
This adds a width of 100% to the sidebar menu elements w/o breaking responsiveness. 🚧