### PR TITLE
🐛 fix(sidebar): adding z index to the mobile menu

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -112,6 +112,7 @@
       align-items: center;
       transition: 0.3s;
       transform: translateX(100%);
+      z-index: 99;
 
       list-style-type: none;
       margin: 0;


### PR DESCRIPTION
This adds a `z-index` property to the sidebar to avoid layering problems. 🚧